### PR TITLE
서울 공원 현황 및 관광자연 open api 연결

### DIFF
--- a/commas/build.gradle
+++ b/commas/build.gradle
@@ -32,7 +32,6 @@ dependencies {
 
 	//webclient
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	implementation 'io.projectreactor:reactor-spring'
 }
 
 tasks.named('test') {

--- a/commas/src/main/java/tight/commas/domain/park/api/ParkApi.java
+++ b/commas/src/main/java/tight/commas/domain/park/api/ParkApi.java
@@ -1,0 +1,96 @@
+package tight.commas.domain.park.api;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+import tight.commas.domain.park.dto.ParkDto;
+import tight.commas.utils.WebClientUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class ParkApi {
+
+    private final WebClientUtils webClientUtils;
+
+    private final String BASE_URL = "http://openAPI.seoul.go.kr:8088";
+
+    @Value("${api.key}")
+    private String apiKey;
+
+    @Autowired
+    public ParkApi(WebClientUtils webClientUtils) {
+        this.webClientUtils = webClientUtils;
+    }
+
+    public List<ParkDto> getParkInfo() {
+        String key = apiKey;
+        String service = "SearchParkInfoService";
+        int startIndex = 1;
+        int endIndex = 10;
+
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .path("/{key}/json/{service}/{startIndex}/{endIndex}/")
+                .buildAndExpand(key, service, startIndex, endIndex)
+                .toUriString();
+
+        Mono<Map> responseMono = webClientUtils.get(url, Map.class);
+
+        Map<String, Object> response = responseMono.block();
+
+        Map<String, Object> parkService = (Map<String, Object>) response.get(service);
+        List<Map<String, Object>> parkList = (List<Map<String, Object>>) parkService.get("row");
+
+        return parkList.stream()
+                .map(parkData -> {
+                    String name = (String) parkData.get("P_PARK");
+                    String content = (String) parkData.get("P_LIST_CONTENT");
+                    String address = (String) parkData.get("P_ADDR");
+                    String mainEquip = (String) parkData.get("MAIN_EQUIP");
+                    String mainPlant = (String) parkData.get("MAIN_PLANTS");
+                    String imageUrl = (String) parkData.get("P_IMG");
+                    double latitude = Double.parseDouble((String) parkData.get("LATITUDE"));
+                    double longitude = Double.parseDouble((String) parkData.get("LONGITUDE"));
+
+                    return new ParkDto(name, content, address, mainEquip, mainPlant, imageUrl, latitude, longitude);
+                }).collect(Collectors.toList());
+    }
+
+    public List<ParkDto> getNaturalTourismInfo() {
+        String key = apiKey;
+        String service = "TbVwNature";
+        int startIndex = 1;
+        int endIndex = 100;
+
+        String url = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .path("/{key}/json/{service}/{startIndex}/{endIndex}/")
+                .buildAndExpand(key, service, startIndex, endIndex)
+                .toUriString();
+
+        UriComponentsBuilder.fromHttpUrl(BASE_URL)
+                .path("/{key}/json/{service}/{startIndex}/{endIndex}/")
+                .buildAndExpand(key, service, startIndex, endIndex)
+                .toUriString();
+
+        Mono<Map> responseMono = webClientUtils.get(url, Map.class);
+
+        Map<String, Object> response = responseMono.block();
+
+        Map<String, Object> naturalTourismService = (Map<String, Object>) response.get(service);
+        List<Map<String, Object>> naturalTourismList = (List<Map<String, Object>>) naturalTourismService.get("row");
+
+        return naturalTourismList.stream()
+                .filter(naturalTourismData -> "ko".equals(naturalTourismData.get("LANG_CODE_ID")))
+                .map(naturalTourismData -> {
+                    String name = (String) naturalTourismData.get("POST_SJ");
+                    String address = (String) naturalTourismData.get("NEW_ADDRESS");
+
+                    return new ParkDto(name, address);
+                }).collect(Collectors.toList());
+    }
+}
+

--- a/commas/src/main/java/tight/commas/domain/park/controller/ParkApiController.java
+++ b/commas/src/main/java/tight/commas/domain/park/controller/ParkApiController.java
@@ -1,0 +1,36 @@
+package tight.commas.domain.park.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tight.commas.domain.park.api.ParkApi;
+import tight.commas.domain.park.dto.ParkDto;
+
+import java.util.List;
+
+@RestController
+public class ParkApiController {
+
+    private final ParkApi parkApi;
+
+    @Autowired
+    public ParkApiController(ParkApi parkApi) {
+        this.parkApi = parkApi;
+    }
+
+    @GetMapping("/api/park")
+    public ResponseEntity<List<ParkDto>> getParkInfo() {
+
+        return ResponseEntity.ok(parkApi.getParkInfo());
+    }
+
+    @GetMapping("/api/naturalTourism")
+    public ResponseEntity<List<ParkDto>> getNaturalTourismInfo() {
+
+        return ResponseEntity.ok(parkApi.getNaturalTourismInfo());
+    }
+}
+
+
+

--- a/commas/src/main/java/tight/commas/domain/park/dto/ParkDto.java
+++ b/commas/src/main/java/tight/commas/domain/park/dto/ParkDto.java
@@ -1,0 +1,33 @@
+package tight.commas.domain.park.dto;
+
+import lombok.Data;
+
+@Data
+public class ParkDto {
+    private String name;
+    private String content;
+    private String address;
+    private String mainEquip;
+    private String mainPlant;
+    private String imageUrl;
+    private double latitude;
+    private double longitude;
+
+
+    public ParkDto(String name, String address) {
+        this.name = name;
+        this.address = address;
+    }
+
+    public ParkDto(String name, String content, String address, String mainEquip, String mainPlant, String imageUrl, double latitude, double longitude) {
+        this.name = name;
+        this.content = content;
+        this.address = address;
+        this.mainEquip = mainEquip;
+        this.mainPlant = mainPlant;
+        this.imageUrl = imageUrl;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}
+

--- a/commas/src/main/java/tight/commas/domain/park/entity/Park.java
+++ b/commas/src/main/java/tight/commas/domain/park/entity/Park.java
@@ -1,11 +1,15 @@
-package tight.commas.domain;
+package tight.commas.domain.park.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import tight.commas.domain.Address;
+import tight.commas.domain.BaseTimeEntity;
+import tight.commas.domain.Chat;
+import tight.commas.domain.User;
 
 @Entity
 @Getter
-public class Park extends BaseTimeEntity{
+public class Park extends BaseTimeEntity {
 
     @Id @GeneratedValue
     @Column(name = "park_id")
@@ -23,9 +27,6 @@ public class Park extends BaseTimeEntity{
     private Address address;
 
     private String imageUrl;
-
-    private int openTime;
-    private int endTime;
 
     private int phoneNumber;
 


### PR DESCRIPTION
## 변경 사항 요약

: 서울 열린데이터 광장에서 제공하는 서울 공원 현황 및 관광자연 open api를 연결했습니다.  

## 변경 사항 상세 내역

: webclient를 통해 서울 공원 현황 및 관광자연 open api 를 연결하고, 필요한 필드들만을 받아서 제공할 수 있도록 api를 구현하였습니다. 

<img width="1066" alt="스크린샷 2024-03-21 오후 4 20 45" src="https://github.com/wminsoo1/commas/assets/81519167/d344d1aa-e00e-46cf-8cc2-9bd99443304d">



## 비고 

추가해야할 필드가 있을지 논의가 필요할 것 같습니다.
리뷰 부탁드립니다 :)